### PR TITLE
Elevator Tuning

### DIFF
--- a/AdvantageKit/elevator-tuning.json
+++ b/AdvantageKit/elevator-tuning.json
@@ -1,0 +1,128 @@
+{
+  "hubs": [
+    {
+      "x": 576,
+      "y": 37,
+      "width": 893,
+      "height": 831,
+      "state": {
+        "sidebar": {
+          "width": 336,
+          "expanded": [
+            "/AdvantageKit",
+            "/AdvantageKit/RealOutputs",
+            "/AdvantageKit/RealOutputs/FieldSimulation",
+            "/AdvantageKit/RealOutputs/Odometry",
+            "/AdvantageKit/RealOutputs/RobotContainer",
+            "/AdvantageKit/RealOutputs/FieldSimulation/RobotPosition",
+            "/AdvantageKit/RealOutputs/Snap",
+            "/AdvantageKit/RealOutputs/SwerveStates",
+            "/AdvantageKit/RealOutputs/Elevator",
+            "/AdvantageKit/Elevator",
+            "/Tuning",
+            "/Tuning/Elevator"
+          ]
+        },
+        "tabs": {
+          "selected": 1,
+          "tabs": [
+            {
+              "type": 0,
+              "title": "",
+              "controller": null,
+              "controllerUUID": "wixayhdk297lvc1z710q7vjqysorpr70",
+              "renderer": "#/",
+              "controlsHeight": 0
+            },
+            {
+              "type": 1,
+              "title": "Line Graph",
+              "controller": {
+                "leftSources": [
+                  {
+                    "type": "stepped",
+                    "logKey": "NT:/AdvantageKit/RealOutputs/Elevator/EstimatedHeight",
+                    "logType": "Number",
+                    "visible": true,
+                    "options": {
+                      "color": "#2b66a2",
+                      "size": "normal"
+                    }
+                  },
+                  {
+                    "type": "stepped",
+                    "logKey": "NT:/AdvantageKit/RealOutputs/Elevator/CurrentLevelHeight",
+                    "logType": "Number",
+                    "visible": true,
+                    "options": {
+                      "color": "#3b875a",
+                      "size": "normal"
+                    }
+                  }
+                ],
+                "rightSources": [
+                  {
+                    "type": "stepped",
+                    "logKey": "NT:/AdvantageKit/Elevator/WinchVelocity",
+                    "logType": "Number",
+                    "visible": true,
+                    "options": {
+                      "color": "#e48b32",
+                      "size": "normal"
+                    }
+                  }
+                ],
+                "discreteSources": [
+                  {
+                    "type": "stripes",
+                    "logKey": "NT:/AdvantageKit/RealOutputs/Elevator/lowerLimitHIt",
+                    "logType": "Boolean",
+                    "visible": true,
+                    "options": {
+                      "color": "#af2437"
+                    }
+                  },
+                  {
+                    "type": "stripes",
+                    "logKey": "NT:/AdvantageKit/RealOutputs/Elevator/isAtGoal",
+                    "logType": "Boolean",
+                    "visible": true,
+                    "options": {
+                      "color": "#3b875a"
+                    }
+                  },
+                  {
+                    "type": "stripes",
+                    "logKey": "NT:/AdvantageKit/RealOutputs/Elevator/CurrentLevel",
+                    "logType": "String",
+                    "visible": true,
+                    "options": {
+                      "color": "#e5b31b"
+                    }
+                  }
+                ],
+                "leftLockedRange": null,
+                "rightLockedRange": null,
+                "leftUnitConversion": {
+                  "type": null,
+                  "factor": 1
+                },
+                "rightUnitConversion": {
+                  "type": null,
+                  "factor": 1
+                },
+                "leftFilter": 0,
+                "rightFilter": 0
+              },
+              "controllerUUID": "ftkrece16kiity2lwjdx1el9owha9roi",
+              "renderer": null,
+              "controlsHeight": 200
+            }
+          ]
+        }
+      }
+    }
+  ],
+  "satellites": [],
+  "version": "4.1.2"
+}

--- a/src/main/java/frc/lib/tunables/LoggedTunableBoolean.java
+++ b/src/main/java/frc/lib/tunables/LoggedTunableBoolean.java
@@ -1,0 +1,45 @@
+package frc.lib.tunables;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.function.Consumer;
+
+import org.littletonrobotics.junction.networktables.LoggedNetworkBoolean;
+
+import edu.wpi.first.networktables.BooleanEntry;
+import edu.wpi.first.networktables.NetworkTableInstance;
+import edu.wpi.first.networktables.PubSubOption;
+
+public class LoggedTunableBoolean extends LoggedNetworkBoolean {
+
+  private BooleanEntry entry;
+  private List<Consumer<Boolean>> listeners;
+
+  public LoggedTunableBoolean(String key, boolean defaultValue) {
+    super(key, defaultValue);
+    entry = NetworkTableInstance.getDefault().getBooleanTopic(key).getEntry(defaultValue,
+        PubSubOption.keepDuplicates(false), PubSubOption.pollStorage(1));
+    listeners = new ArrayList<>();
+  }
+
+  public void addListener(Consumer<Boolean> listener) {
+    listeners.add(listener);
+    listener.accept(entry.get());
+  }
+
+  public void removeListener(Consumer<Boolean> listener) {
+    listeners.remove(listener);
+  }
+
+  @Override
+  public void periodic() {
+    super.periodic();
+    var changes = entry.readQueueValues();
+    if (changes.length == 1) {
+      var newValue = changes[0];
+      for (var listener : listeners) {
+        listener.accept(newValue);
+      }
+    }
+  }
+}

--- a/src/main/java/frc/lib/tunables/LoggedTunableNumber.java
+++ b/src/main/java/frc/lib/tunables/LoggedTunableNumber.java
@@ -1,0 +1,45 @@
+package frc.lib.tunables;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.function.Consumer;
+
+import org.littletonrobotics.junction.networktables.LoggedNetworkNumber;
+
+import edu.wpi.first.networktables.DoubleEntry;
+import edu.wpi.first.networktables.NetworkTableInstance;
+import edu.wpi.first.networktables.PubSubOption;
+
+public class LoggedTunableNumber extends LoggedNetworkNumber {
+
+  private DoubleEntry entry;
+  private List<Consumer<Double>> listeners;
+
+  public LoggedTunableNumber(String key, double defaultValue) {
+    super(key, defaultValue);
+    entry = NetworkTableInstance.getDefault().getDoubleTopic(key).getEntry(defaultValue,
+        PubSubOption.keepDuplicates(false), PubSubOption.pollStorage(1));
+    listeners = new ArrayList<>();
+  }
+
+  public void addListener(Consumer<Double> listener) {
+    listeners.add(listener);
+    listener.accept(entry.get());
+  }
+
+  public void removeListener(Consumer<Double> listener) {
+    listeners.remove(listener);
+  }
+
+  @Override
+  public void periodic() {
+    super.periodic();
+    var changes = entry.readQueueValues();
+    if (changes.length == 1) {
+      var newValue = changes[0];
+      for (var listener : listeners) {
+        listener.accept(newValue);
+      }
+    }
+  }
+}

--- a/src/main/java/frc/lib/tunables/LoggedTunableString.java
+++ b/src/main/java/frc/lib/tunables/LoggedTunableString.java
@@ -1,0 +1,45 @@
+package frc.lib.tunables;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.function.Consumer;
+
+import org.littletonrobotics.junction.networktables.LoggedNetworkString;
+
+import edu.wpi.first.networktables.StringEntry;
+import edu.wpi.first.networktables.NetworkTableInstance;
+import edu.wpi.first.networktables.PubSubOption;
+
+public class LoggedTunableString extends LoggedNetworkString {
+
+  private StringEntry entry;
+  private List<Consumer<String>> listeners;
+
+  public LoggedTunableString(String key, String defaultValue) {
+    super(key, defaultValue);
+    entry = NetworkTableInstance.getDefault().getStringTopic(key).getEntry(defaultValue,
+        PubSubOption.keepDuplicates(false), PubSubOption.pollStorage(1));
+    listeners = new ArrayList<>();
+  }
+
+  public void addListener(Consumer<String> listener) {
+    listeners.add(listener);
+    listener.accept(entry.get());
+  }
+
+  public void removeListener(Consumer<String> listener) {
+    listeners.remove(listener);
+  }
+
+  @Override
+  public void periodic() {
+    super.periodic();
+    var changes = entry.readQueueValues();
+    if (changes.length == 1) {
+      var newValue = changes[0];
+      for (var listener : listeners) {
+        listener.accept(newValue);
+      }
+    }
+  }
+}

--- a/src/main/java/frc/robot/Robot25/subsystems/elevator/ElevatorConstants.java
+++ b/src/main/java/frc/robot/Robot25/subsystems/elevator/ElevatorConstants.java
@@ -4,6 +4,7 @@ import static edu.wpi.first.units.Units.Amps;
 import static edu.wpi.first.units.Units.Inches;
 import static edu.wpi.first.units.Units.InchesPerSecond;
 import static edu.wpi.first.units.Units.KilogramSquareMeters;
+import static edu.wpi.first.units.Units.Meters;
 import static edu.wpi.first.units.Units.Pounds;
 import static edu.wpi.first.units.Units.RadiansPerSecondPerSecond;
 import static edu.wpi.first.units.Units.Volts;
@@ -33,18 +34,21 @@ public class ElevatorConstants {
   public static final Distance INITIAL_HEIGHT = Inches.of(16.4);
   public static final Distance MAX_EXTENSION = Inches.of(80);
   public static final Mass CARRIAGE_MASS = Pounds.of(19.147);
-  public static final LinearVelocity MAX_VELOCITY = InchesPerSecond.of(178.63);
-  public static final AngularAcceleration MAX_ACCELERATION = RadiansPerSecondPerSecond.of(270 / DRUM_RADIUS.in(Inches));
-  public static final Current CURRENT_LIMIT = Amps.of(30);
+  public static final LinearVelocity MAX_VELOCITY = InchesPerSecond.of(121.36); // From recalc
+  public static final AngularAcceleration MAX_ACCELERATION = RadiansPerSecondPerSecond
+      .of(626.72 / DRUM_RADIUS.in(Inches)); // From recalc
+  public static final Current CURRENT_LIMIT = Amps.of(40);
 
   public static final class Real {
-    public static final LoggedNetworkNumber kP = new LoggedNetworkNumber("Tuning/Elevator/kP", 2.0);
-    public static final LoggedNetworkNumber kI = new LoggedNetworkNumber("Tuning/Elevator/kI", 0.0);
+    public static final LoggedNetworkNumber kP = new LoggedNetworkNumber("Tuning/Elevator/kP", 6.0);
+    public static final LoggedNetworkNumber kI = new LoggedNetworkNumber("Tuning/Elevator/kI", 0.2);
     public static final LoggedNetworkNumber kD = new LoggedNetworkNumber("Tuning/Elevator/kD", 0.1);
     public static final LoggedNetworkNumber kS = new LoggedNetworkNumber("Tuning/Elevator/kS", 0.0);
-    public static final LoggedNetworkNumber kG = new LoggedNetworkNumber("Tuning/Elevator/kG", 0.0);
-    public static final LoggedNetworkNumber kV = new LoggedNetworkNumber("Tuning/Elevator/kV", 0.0);
-    public static final LoggedNetworkNumber kA = new LoggedNetworkNumber("Tuning/Elevator/kA", 0.0);
+    public static final LoggedNetworkNumber kG = new LoggedNetworkNumber("Tuning/Elevator/kG", 0.31); // From recalc
+    public static final LoggedNetworkNumber kV = new LoggedNetworkNumber("Tuning/Elevator/kV",
+        0.1 * DRUM_RADIUS.in(Inches)); // 0.10 Vs/in from Recalc
+    public static final LoggedNetworkNumber kA = new LoggedNetworkNumber("Tuning/Elevator/kA",
+        0.004 * DRUM_RADIUS.in(Meters)); // 0.04Vs^2/m from Recalc
 
     public static final double ODOMETRY_FREQUENCY = new CANBus().isNetworkFD() ? 250.0 : 100.0;
   }

--- a/src/main/java/frc/robot/Robot25/subsystems/elevator/ElevatorConstants.java
+++ b/src/main/java/frc/robot/Robot25/subsystems/elevator/ElevatorConstants.java
@@ -9,8 +9,6 @@ import static edu.wpi.first.units.Units.Pounds;
 import static edu.wpi.first.units.Units.RadiansPerSecondPerSecond;
 import static edu.wpi.first.units.Units.Volts;
 
-import org.littletonrobotics.junction.networktables.LoggedNetworkNumber;
-
 import com.ctre.phoenix6.CANBus;
 
 import edu.wpi.first.units.measure.AngularAcceleration;
@@ -20,6 +18,7 @@ import edu.wpi.first.units.measure.LinearVelocity;
 import edu.wpi.first.units.measure.Mass;
 import edu.wpi.first.units.measure.MomentOfInertia;
 import edu.wpi.first.units.measure.Voltage;
+import frc.lib.tunables.LoggedTunableNumber;
 
 /**
  *
@@ -40,14 +39,14 @@ public class ElevatorConstants {
   public static final Current CURRENT_LIMIT = Amps.of(40);
 
   public static final class Real {
-    public static final LoggedNetworkNumber kP = new LoggedNetworkNumber("Tuning/Elevator/kP", 6.0);
-    public static final LoggedNetworkNumber kI = new LoggedNetworkNumber("Tuning/Elevator/kI", 0.2);
-    public static final LoggedNetworkNumber kD = new LoggedNetworkNumber("Tuning/Elevator/kD", 0.1);
-    public static final LoggedNetworkNumber kS = new LoggedNetworkNumber("Tuning/Elevator/kS", 0.0);
-    public static final LoggedNetworkNumber kG = new LoggedNetworkNumber("Tuning/Elevator/kG", 0.31); // From recalc
-    public static final LoggedNetworkNumber kV = new LoggedNetworkNumber("Tuning/Elevator/kV",
+    public static final LoggedTunableNumber kP = new LoggedTunableNumber("Tuning/Elevator/kP", 6.0);
+    public static final LoggedTunableNumber kI = new LoggedTunableNumber("Tuning/Elevator/kI", 0.2);
+    public static final LoggedTunableNumber kD = new LoggedTunableNumber("Tuning/Elevator/kD", 0.1);
+    public static final LoggedTunableNumber kS = new LoggedTunableNumber("Tuning/Elevator/kS", 0.0);
+    public static final LoggedTunableNumber kG = new LoggedTunableNumber("Tuning/Elevator/kG", 0.31); // From recalc
+    public static final LoggedTunableNumber kV = new LoggedTunableNumber("Tuning/Elevator/kV",
         0.1 * DRUM_RADIUS.in(Inches)); // 0.10 Vs/in from Recalc
-    public static final LoggedNetworkNumber kA = new LoggedNetworkNumber("Tuning/Elevator/kA",
+    public static final LoggedTunableNumber kA = new LoggedTunableNumber("Tuning/Elevator/kA",
         0.004 * DRUM_RADIUS.in(Meters)); // 0.04Vs^2/m from Recalc
 
     public static final double ODOMETRY_FREQUENCY = new CANBus().isNetworkFD() ? 250.0 : 100.0;

--- a/src/main/java/frc/robot/Robot25/subsystems/elevator/ElevatorConstants.java
+++ b/src/main/java/frc/robot/Robot25/subsystems/elevator/ElevatorConstants.java
@@ -8,6 +8,8 @@ import static edu.wpi.first.units.Units.Pounds;
 import static edu.wpi.first.units.Units.RadiansPerSecondPerSecond;
 import static edu.wpi.first.units.Units.Volts;
 
+import org.littletonrobotics.junction.networktables.LoggedNetworkNumber;
+
 import com.ctre.phoenix6.CANBus;
 
 import edu.wpi.first.units.measure.AngularAcceleration;
@@ -28,22 +30,21 @@ public class ElevatorConstants {
   public static final Distance DRUM_RADIUS = Inches.of(1);
   public static final double GEARING = 5.0;
   public static final Distance MIN_HEIGHT = Inches.of(16.4);
-  public static final Distance INITIAL_HEIGHT = Inches.of(16.3);
+  public static final Distance INITIAL_HEIGHT = Inches.of(16.4);
   public static final Distance MAX_EXTENSION = Inches.of(80);
   public static final Mass CARRIAGE_MASS = Pounds.of(19.147);
   public static final LinearVelocity MAX_VELOCITY = InchesPerSecond.of(178.63);
-  public static final AngularAcceleration MAX_ACCELERATION =
-      RadiansPerSecondPerSecond.of(90 / DRUM_RADIUS.in(Inches));
-  public static final Current CURRENT_LIMIT = Amps.of(40);
+  public static final AngularAcceleration MAX_ACCELERATION = RadiansPerSecondPerSecond.of(270 / DRUM_RADIUS.in(Inches));
+  public static final Current CURRENT_LIMIT = Amps.of(30);
 
   public static final class Real {
-    public static final double kP = 2;
-    public static final double kI = 0;
-    public static final double kD = 0.1;
-    public static final double kS = 0;
-    public static final double kG = 0;
-    public static final double kV = 0;
-    public static final double kA = 0;
+    public static final LoggedNetworkNumber kP = new LoggedNetworkNumber("Tuning/Elevator/kP", 2.0);
+    public static final LoggedNetworkNumber kI = new LoggedNetworkNumber("Tuning/Elevator/kI", 0.0);
+    public static final LoggedNetworkNumber kD = new LoggedNetworkNumber("Tuning/Elevator/kD", 0.1);
+    public static final LoggedNetworkNumber kS = new LoggedNetworkNumber("Tuning/Elevator/kS", 0.0);
+    public static final LoggedNetworkNumber kG = new LoggedNetworkNumber("Tuning/Elevator/kG", 0.0);
+    public static final LoggedNetworkNumber kV = new LoggedNetworkNumber("Tuning/Elevator/kV", 0.0);
+    public static final LoggedNetworkNumber kA = new LoggedNetworkNumber("Tuning/Elevator/kA", 0.0);
 
     public static final double ODOMETRY_FREQUENCY = new CANBus().isNetworkFD() ? 250.0 : 100.0;
   }

--- a/src/main/java/frc/robot/Robot25/subsystems/elevator/ElevatorConstants.java
+++ b/src/main/java/frc/robot/Robot25/subsystems/elevator/ElevatorConstants.java
@@ -34,8 +34,8 @@ public class ElevatorConstants {
   public static final Distance MAX_EXTENSION = Inches.of(80);
   public static final Mass CARRIAGE_MASS = Pounds.of(19.147);
   public static final LinearVelocity MAX_VELOCITY = InchesPerSecond.of(121.36); // From recalc
-  public static final AngularAcceleration MAX_ACCELERATION = RadiansPerSecondPerSecond
-      .of(626.72 / DRUM_RADIUS.in(Inches)); // From recalc
+  public static final AngularAcceleration MAX_ACCELERATION =
+      RadiansPerSecondPerSecond.of(626.72 / DRUM_RADIUS.in(Inches)); // From recalc
   public static final Current CURRENT_LIMIT = Amps.of(40);
 
   public static final class Real {
@@ -43,11 +43,15 @@ public class ElevatorConstants {
     public static final LoggedTunableNumber kI = new LoggedTunableNumber("Tuning/Elevator/kI", 0.2);
     public static final LoggedTunableNumber kD = new LoggedTunableNumber("Tuning/Elevator/kD", 0.1);
     public static final LoggedTunableNumber kS = new LoggedTunableNumber("Tuning/Elevator/kS", 0.0);
-    public static final LoggedTunableNumber kG = new LoggedTunableNumber("Tuning/Elevator/kG", 0.31); // From recalc
-    public static final LoggedTunableNumber kV = new LoggedTunableNumber("Tuning/Elevator/kV",
-        0.1 * DRUM_RADIUS.in(Inches)); // 0.10 Vs/in from Recalc
-    public static final LoggedTunableNumber kA = new LoggedTunableNumber("Tuning/Elevator/kA",
-        0.004 * DRUM_RADIUS.in(Meters)); // 0.04Vs^2/m from Recalc
+    public static final LoggedTunableNumber kG =
+        new LoggedTunableNumber("Tuning/Elevator/kG", 0.31); // From recalc
+    public static final LoggedTunableNumber kV =
+        new LoggedTunableNumber("Tuning/Elevator/kV", 0.1 * DRUM_RADIUS.in(Inches)); // 0.10 Vs/in
+                                                                                     // from Recalc
+    public static final LoggedTunableNumber kA =
+        new LoggedTunableNumber("Tuning/Elevator/kA", 0.004 * DRUM_RADIUS.in(Meters)); // 0.04Vs^2/m
+                                                                                       // from
+                                                                                       // Recalc
 
     public static final double ODOMETRY_FREQUENCY = new CANBus().isNetworkFD() ? 250.0 : 100.0;
   }

--- a/src/main/java/frc/robot/Robot25/subsystems/elevator/ElevatorIOTalonFXNew.java
+++ b/src/main/java/frc/robot/Robot25/subsystems/elevator/ElevatorIOTalonFXNew.java
@@ -77,16 +77,37 @@ public class ElevatorIOTalonFXNew implements ElevatorIO {
 
     leadConfig.MotorOutput.NeutralMode = NeutralModeValue.Brake;
 
-    currentPids.kP = Real.kP.get();
-    currentPids.kI = Real.kI.get();
-    currentPids.kD = Real.kD.get();
-    currentPids.kS = Real.kS.get();
-    currentPids.kG = Real.kG.get();
-    currentPids.kV = Real.kV.get();
-    currentPids.kA = Real.kA.get();
     leadConfig.Slot0 = currentPids;
+    Real.kP.addListener(kP -> {
+      currentPids.kP = kP;
+      lead.getConfigurator().apply(currentPids);
+    });
+    Real.kI.addListener(kI -> {
+      currentPids.kI = kI;
+      lead.getConfigurator().apply(currentPids);
+    });
+    Real.kD.addListener(kD -> {
+      currentPids.kD = kD;
+      lead.getConfigurator().apply(currentPids);
+    });
+    Real.kS.addListener(kS -> {
+      currentPids.kS = kS;
+      lead.getConfigurator().apply(currentPids);
+    });
+    Real.kG.addListener(kG -> {
+      currentPids.kG = kG;
+      lead.getConfigurator().apply(currentPids);
+    });
+    Real.kV.addListener(kV -> {
+      currentPids.kV = kV;
+      lead.getConfigurator().apply(currentPids);
+    });
+    Real.kA.addListener(kA -> {
+      currentPids.kA = kA;
+      lead.getConfigurator().apply(currentPids);
+    });
 
-    lead.getConfigurator().apply(leadConfig, .25);
+    lead.getConfigurator().apply(leadConfig, 0.25);
     lead.setPosition(0);
     follower.setControl(new Follower(rightMotorID, true));
 
@@ -110,38 +131,17 @@ public class ElevatorIOTalonFXNew implements ElevatorIO {
   @Override
   public void zeroEncoder() {
     lead.setPosition(0);
-
   }
 
   @Override
   public void updateInputs(ElevatorIOInputs inputs) {
-
-    Logger.recordOutput("MatchType", DriverStation.getMatchType());
-
-    // if not in a comp match and tuner values have changed; not supposed to
-    // periodically apply configs
-    if (DriverStation.getMatchType() == MatchType.None) {
-      if (currentPids.kP != Real.kP.get() || currentPids.kI != Real.kI.get() || currentPids.kD != Real.kD.get()
-          || currentPids.kS != Real.kS.get() || currentPids.kG != Real.kG.get() || currentPids.kV != Real.kV.get()
-          || currentPids.kA != Real.kA.get()) {
-        currentPids.kP = Real.kP.get();
-        currentPids.kI = Real.kI.get();
-        currentPids.kD = Real.kD.get();
-        currentPids.kS = Real.kS.get();
-        currentPids.kG = Real.kG.get();
-        currentPids.kV = Real.kV.get();
-        currentPids.kA = Real.kA.get();
-        lead.getConfigurator().apply(currentPids);
-      }
-    }
-
     var connectedStatus = BaseStatusSignal.refreshAll(leadCurrent, leadVoltage, leadPosition, leadVelocity);
+
     inputs.winchPosition = leadPosition.getValue();
     inputs.lowerLimit = lowerLimitSwitch.get();
     inputs.winchConnected = leadConnectedDebouncer.calculate(connectedStatus.isOK());
     inputs.winchVelocity = leadVelocity.getValue();
     inputs.winchCurrent = leadCurrent.getValue();
     inputs.winchAppliedVolts = leadVoltage.getValue();
-    // System.out.println(lowerLimitSwitch.get());
   }
 }

--- a/src/main/java/frc/robot/Robot25/subsystems/elevator/ElevatorIOTalonFXNew.java
+++ b/src/main/java/frc/robot/Robot25/subsystems/elevator/ElevatorIOTalonFXNew.java
@@ -1,17 +1,20 @@
 package frc.robot.Robot25.subsystems.elevator;
 
+import static edu.wpi.first.units.Units.Amps;
 import static edu.wpi.first.units.Units.Meters;
 import static edu.wpi.first.units.Units.MetersPerSecond;
 import static edu.wpi.first.units.Units.RadiansPerSecond;
 import static edu.wpi.first.units.Units.RotationsPerSecond;
 import static edu.wpi.first.units.Units.RotationsPerSecondPerSecond;
 import static edu.wpi.first.units.Units.Volts;
+import static frc.robot.Robot25.subsystems.elevator.ElevatorConstants.CURRENT_LIMIT;
 import static frc.robot.Robot25.subsystems.elevator.ElevatorConstants.DRUM_RADIUS;
 import static frc.robot.Robot25.subsystems.elevator.ElevatorConstants.GEARING;
 import static frc.robot.Robot25.subsystems.elevator.ElevatorConstants.MAX_ACCELERATION;
 import static frc.robot.Robot25.subsystems.elevator.ElevatorConstants.MAX_VELOCITY;
 import com.ctre.phoenix6.BaseStatusSignal;
 import com.ctre.phoenix6.StatusSignal;
+import com.ctre.phoenix6.configs.Slot0Configs;
 import com.ctre.phoenix6.configs.TalonFXConfiguration;
 import com.ctre.phoenix6.controls.Follower;
 import com.ctre.phoenix6.controls.MotionMagicVoltage;
@@ -25,14 +28,15 @@ import edu.wpi.first.units.measure.Angle;
 import edu.wpi.first.units.measure.AngularVelocity;
 import edu.wpi.first.units.measure.Current;
 import edu.wpi.first.units.measure.Voltage;
+import edu.wpi.first.wpilibj.DriverStation;
+import edu.wpi.first.wpilibj.DriverStation.MatchType;
 import frc.lib.devices.DigitalInputWrapper;
 import frc.robot.Robot25.subsystems.elevator.ElevatorConstants.Real;
 import org.littletonrobotics.junction.Logger;
 
 public class ElevatorIOTalonFXNew implements ElevatorIO {
 
-  private final DigitalInputWrapper lowerLimitSwitch =
-      new DigitalInputWrapper(3, "lowerLimit", true);
+  private final DigitalInputWrapper lowerLimitSwitch = new DigitalInputWrapper(3, "lowerLimit", true);
   private final TalonFX lead, follower;
   private final StatusSignal<Angle> leadPosition;
   private final StatusSignal<AngularVelocity> leadVelocity;
@@ -57,27 +61,26 @@ public class ElevatorIOTalonFXNew implements ElevatorIO {
     leadConfig.MotorOutput.Inverted = InvertedValue.CounterClockwise_Positive;
     leadConfig.Feedback.FeedbackSensorSource = FeedbackSensorSourceValue.RotorSensor;
 
-    leadConfig.CurrentLimits.SupplyCurrentLimit = 20;
+    leadConfig.CurrentLimits.SupplyCurrentLimit = CURRENT_LIMIT.in(Amps);
     leadConfig.CurrentLimits.SupplyCurrentLimitEnable = true;
     leadConfig.Feedback.SensorToMechanismRatio = GEARING;
 
-    leadConfig.Voltage.PeakForwardVoltage = 8;
-    leadConfig.Voltage.PeakReverseVoltage = -8;
+    leadConfig.Voltage.PeakForwardVoltage = 10;
+    leadConfig.Voltage.PeakReverseVoltage = -10;
 
-    leadConfig.MotionMagic.MotionMagicAcceleration =
-        MAX_ACCELERATION.in(RotationsPerSecondPerSecond);
+    leadConfig.MotionMagic.MotionMagicAcceleration = MAX_ACCELERATION.in(RotationsPerSecondPerSecond);
     leadConfig.MotionMagic.MotionMagicCruiseVelocity = RadiansPerSecond
         .of(MAX_VELOCITY.in(MetersPerSecond) / DRUM_RADIUS.in(Meters)).in(RotationsPerSecond);
 
     leadConfig.MotorOutput.NeutralMode = NeutralModeValue.Brake;
 
-    leadConfig.Slot0.kP = Real.kP;
-    leadConfig.Slot0.kI = Real.kI;
-    leadConfig.Slot0.kD = Real.kD;
-    leadConfig.Slot0.kS = Real.kS;
-    leadConfig.Slot0.kG = Real.kG;
-    leadConfig.Slot0.kV = Real.kV;
-    leadConfig.Slot0.kA = Real.kA;
+    leadConfig.Slot0.kP = Real.kP.get();
+    leadConfig.Slot0.kI = Real.kI.get();
+    leadConfig.Slot0.kD = Real.kD.get();
+    leadConfig.Slot0.kS = Real.kS.get();
+    leadConfig.Slot0.kG = Real.kG.get();
+    leadConfig.Slot0.kV = Real.kV.get();
+    leadConfig.Slot0.kA = Real.kA.get();
 
     lead.getConfigurator().apply(leadConfig, .25);
     lead.setPosition(0);
@@ -108,8 +111,21 @@ public class ElevatorIOTalonFXNew implements ElevatorIO {
 
   @Override
   public void updateInputs(ElevatorIOInputs inputs) {
-    var connectedStatus =
-        BaseStatusSignal.refreshAll(leadCurrent, leadVoltage, leadPosition, leadVelocity);
+
+    Logger.recordOutput("MatchType", DriverStation.getMatchType());
+    if (DriverStation.getMatchType() == MatchType.None) {
+      var currentPids = new Slot0Configs();
+      currentPids.kP = Real.kP.get();
+      currentPids.kI = Real.kI.get();
+      currentPids.kD = Real.kD.get();
+      currentPids.kS = Real.kS.get();
+      currentPids.kG = Real.kG.get();
+      currentPids.kV = Real.kV.get();
+      currentPids.kA = Real.kA.get();
+      lead.getConfigurator().apply(currentPids);
+    }
+
+    var connectedStatus = BaseStatusSignal.refreshAll(leadCurrent, leadVoltage, leadPosition, leadVelocity);
     inputs.winchPosition = leadPosition.getValue();
     inputs.lowerLimit = lowerLimitSwitch.get();
     inputs.winchConnected = leadConnectedDebouncer.calculate(connectedStatus.isOK());

--- a/src/main/java/frc/robot/Robot25/subsystems/elevator/ElevatorIOTalonFXNew.java
+++ b/src/main/java/frc/robot/Robot25/subsystems/elevator/ElevatorIOTalonFXNew.java
@@ -36,7 +36,8 @@ import org.littletonrobotics.junction.Logger;
 
 public class ElevatorIOTalonFXNew implements ElevatorIO {
 
-  private final DigitalInputWrapper lowerLimitSwitch = new DigitalInputWrapper(3, "lowerLimit", true);
+  private final DigitalInputWrapper lowerLimitSwitch =
+      new DigitalInputWrapper(3, "lowerLimit", true);
   private final TalonFX lead, follower;
   private final StatusSignal<Angle> leadPosition;
   private final StatusSignal<AngularVelocity> leadVelocity;
@@ -71,7 +72,8 @@ public class ElevatorIOTalonFXNew implements ElevatorIO {
     leadConfig.Voltage.PeakForwardVoltage = 10;
     leadConfig.Voltage.PeakReverseVoltage = -10;
 
-    leadConfig.MotionMagic.MotionMagicAcceleration = MAX_ACCELERATION.in(RotationsPerSecondPerSecond);
+    leadConfig.MotionMagic.MotionMagicAcceleration =
+        MAX_ACCELERATION.in(RotationsPerSecondPerSecond);
     leadConfig.MotionMagic.MotionMagicCruiseVelocity = RadiansPerSecond
         .of(MAX_VELOCITY.in(MetersPerSecond) / DRUM_RADIUS.in(Meters)).in(RotationsPerSecond);
 
@@ -135,7 +137,8 @@ public class ElevatorIOTalonFXNew implements ElevatorIO {
 
   @Override
   public void updateInputs(ElevatorIOInputs inputs) {
-    var connectedStatus = BaseStatusSignal.refreshAll(leadCurrent, leadVoltage, leadPosition, leadVelocity);
+    var connectedStatus =
+        BaseStatusSignal.refreshAll(leadCurrent, leadVoltage, leadPosition, leadVelocity);
 
     inputs.winchPosition = leadPosition.getValue();
     inputs.lowerLimit = lowerLimitSwitch.get();

--- a/src/main/java/frc/robot/Robot25/subsystems/elevator/ElevatorIOTalonFXNew.java
+++ b/src/main/java/frc/robot/Robot25/subsystems/elevator/ElevatorIOTalonFXNew.java
@@ -46,6 +46,9 @@ public class ElevatorIOTalonFXNew implements ElevatorIO {
   private final int leftMotorID = 21;
   private final Debouncer leadConnectedDebouncer = new Debouncer(.5);
 
+  // Current PIDS
+  private Slot0Configs currentPids = new Slot0Configs();
+
   public ElevatorIOTalonFXNew() {
 
     lead = new TalonFX(rightMotorID);
@@ -74,13 +77,14 @@ public class ElevatorIOTalonFXNew implements ElevatorIO {
 
     leadConfig.MotorOutput.NeutralMode = NeutralModeValue.Brake;
 
-    leadConfig.Slot0.kP = Real.kP.get();
-    leadConfig.Slot0.kI = Real.kI.get();
-    leadConfig.Slot0.kD = Real.kD.get();
-    leadConfig.Slot0.kS = Real.kS.get();
-    leadConfig.Slot0.kG = Real.kG.get();
-    leadConfig.Slot0.kV = Real.kV.get();
-    leadConfig.Slot0.kA = Real.kA.get();
+    currentPids.kP = Real.kP.get();
+    currentPids.kI = Real.kI.get();
+    currentPids.kD = Real.kD.get();
+    currentPids.kS = Real.kS.get();
+    currentPids.kG = Real.kG.get();
+    currentPids.kV = Real.kV.get();
+    currentPids.kA = Real.kA.get();
+    leadConfig.Slot0 = currentPids;
 
     lead.getConfigurator().apply(leadConfig, .25);
     lead.setPosition(0);
@@ -113,16 +117,22 @@ public class ElevatorIOTalonFXNew implements ElevatorIO {
   public void updateInputs(ElevatorIOInputs inputs) {
 
     Logger.recordOutput("MatchType", DriverStation.getMatchType());
+
+    // if not in a comp match and tuner values have changed; not supposed to
+    // periodically apply configs
     if (DriverStation.getMatchType() == MatchType.None) {
-      var currentPids = new Slot0Configs();
-      currentPids.kP = Real.kP.get();
-      currentPids.kI = Real.kI.get();
-      currentPids.kD = Real.kD.get();
-      currentPids.kS = Real.kS.get();
-      currentPids.kG = Real.kG.get();
-      currentPids.kV = Real.kV.get();
-      currentPids.kA = Real.kA.get();
-      lead.getConfigurator().apply(currentPids);
+      if (currentPids.kP != Real.kP.get() || currentPids.kI != Real.kI.get() || currentPids.kD != Real.kD.get()
+          || currentPids.kS != Real.kS.get() || currentPids.kG != Real.kG.get() || currentPids.kV != Real.kV.get()
+          || currentPids.kA != Real.kA.get()) {
+        currentPids.kP = Real.kP.get();
+        currentPids.kI = Real.kI.get();
+        currentPids.kD = Real.kD.get();
+        currentPids.kS = Real.kS.get();
+        currentPids.kG = Real.kG.get();
+        currentPids.kV = Real.kV.get();
+        currentPids.kA = Real.kA.get();
+        lead.getConfigurator().apply(currentPids);
+      }
     }
 
     var connectedStatus = BaseStatusSignal.refreshAll(leadCurrent, leadVoltage, leadPosition, leadVelocity);


### PR DESCRIPTION
Here are the highlights:
- Elevator tunable PIDs and FFs in AdvantageScope
- Tuned PID, added estimated FFs from recalc.
  - Time for Intake to L4 went from ~2s to 0.9s
- Increased max acceleration, decreased max velocity as per recalc with up-to-date carriage weight
- Added a really helpful AdvantageScope layout for tuning Elevator PID
