### PR TITLE
A code cleanup PR

### DIFF
--- a/src/main/java/frc/lib/tunables/LoggedTunable.java
+++ b/src/main/java/frc/lib/tunables/LoggedTunable.java
@@ -1,0 +1,54 @@
+package frc.lib.tunables;
+
+import java.lang.ref.WeakReference;
+import java.util.Iterator;
+import java.util.List;
+import java.util.function.Consumer;
+
+import edu.wpi.first.wpilibj.DriverStation;
+import edu.wpi.first.wpilibj.DriverStation.MatchType;
+
+interface LoggedTunable<T> {
+
+  List<WeakReference<Consumer<T>>> getListeners();
+
+  T getValue();
+
+  T getDefaultValue();
+
+  public default void addListener(Consumer<T> listener) {
+    getListeners().add(new WeakReference<>(listener));
+
+    // Only do tunables when not in a match, when in a match, give listener the
+    // default value
+    if (DriverStation.getMatchType() == MatchType.None) {
+      listener.accept(getValue());
+    } else {
+      listener.accept(getDefaultValue());
+    }
+  }
+
+  public default void removeListener(Consumer<T> listener) {
+    Iterator<WeakReference<Consumer<T>>> iter = getListeners().iterator();
+    while (iter.hasNext()) {
+      WeakReference<Consumer<T>> ref = iter.next();
+      Consumer<T> current = ref.get();
+      if (current == null || current == listener) {
+        iter.remove();
+      }
+    }
+  }
+
+  default void notifyListeners() {
+    Iterator<WeakReference<Consumer<T>>> iter = getListeners().iterator();
+    while (iter.hasNext()) {
+      WeakReference<Consumer<T>> ref = iter.next();
+      Consumer<T> listener = ref.get();
+      if (listener != null) {
+        listener.accept(getValue());
+      } else {
+        iter.remove();
+      }
+    }
+  }
+}

--- a/src/main/java/frc/lib/tunables/LoggedTunableBoolean.java
+++ b/src/main/java/frc/lib/tunables/LoggedTunableBoolean.java
@@ -24,7 +24,7 @@ public class LoggedTunableBoolean extends LoggedNetworkBoolean implements Logged
   }
 
   public Boolean getValue() {
-    return entry.get();
+    return get();
   }
 
   public List<WeakReference<Consumer<Boolean>>> getListeners() {

--- a/src/main/java/frc/lib/tunables/LoggedTunableNumber.java
+++ b/src/main/java/frc/lib/tunables/LoggedTunableNumber.java
@@ -1,5 +1,6 @@
 package frc.lib.tunables;
 
+import java.lang.ref.WeakReference;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.function.Consumer;
@@ -9,36 +10,44 @@ import org.littletonrobotics.junction.networktables.LoggedNetworkNumber;
 import edu.wpi.first.networktables.DoubleEntry;
 import edu.wpi.first.networktables.NetworkTableInstance;
 import edu.wpi.first.networktables.PubSubOption;
+import edu.wpi.first.wpilibj.DriverStation;
+import edu.wpi.first.wpilibj.DriverStation.MatchType;
 
-public class LoggedTunableNumber extends LoggedNetworkNumber {
+public class LoggedTunableNumber extends LoggedNetworkNumber implements LoggedTunable<Double> {
 
-  private DoubleEntry entry;
-  private List<Consumer<Double>> listeners;
+  private final double defaultValue;
+  private final DoubleEntry entry;
+  private final List<WeakReference<Consumer<Double>>> listeners;
+
+  public Double getDefaultValue() {
+    return defaultValue;
+  }
+
+  public Double getValue() {
+    return entry.get();
+  }
+
+  public List<WeakReference<Consumer<Double>>> getListeners() {
+    return listeners;
+  }
 
   public LoggedTunableNumber(String key, double defaultValue) {
     super(key, defaultValue);
+    this.defaultValue = defaultValue;
     entry = NetworkTableInstance.getDefault().getDoubleTopic(key).getEntry(defaultValue,
         PubSubOption.keepDuplicates(false), PubSubOption.pollStorage(1));
     listeners = new ArrayList<>();
   }
 
-  public void addListener(Consumer<Double> listener) {
-    listeners.add(listener);
-    listener.accept(entry.get());
-  }
-
-  public void removeListener(Consumer<Double> listener) {
-    listeners.remove(listener);
-  }
-
   @Override
   public void periodic() {
     super.periodic();
-    var changes = entry.readQueueValues();
-    if (changes.length == 1) {
-      var newValue = changes[0];
-      for (var listener : listeners) {
-        listener.accept(newValue);
+
+    // Only do tunables when not in a match
+    if (DriverStation.getMatchType() == MatchType.None) {
+      var changes = entry.readQueueValues();
+      if (changes.length == 1) {
+        notifyListeners();
       }
     }
   }

--- a/src/main/java/frc/lib/tunables/LoggedTunableNumber.java
+++ b/src/main/java/frc/lib/tunables/LoggedTunableNumber.java
@@ -24,7 +24,7 @@ public class LoggedTunableNumber extends LoggedNetworkNumber implements LoggedTu
   }
 
   public Double getValue() {
-    return entry.get();
+    return get();
   }
 
   public List<WeakReference<Consumer<Double>>> getListeners() {

--- a/src/main/java/frc/lib/tunables/LoggedTunableString.java
+++ b/src/main/java/frc/lib/tunables/LoggedTunableString.java
@@ -1,5 +1,6 @@
 package frc.lib.tunables;
 
+import java.lang.ref.WeakReference;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.function.Consumer;
@@ -7,38 +8,46 @@ import java.util.function.Consumer;
 import org.littletonrobotics.junction.networktables.LoggedNetworkString;
 
 import edu.wpi.first.networktables.StringEntry;
+import edu.wpi.first.wpilibj.DriverStation;
+import edu.wpi.first.wpilibj.DriverStation.MatchType;
 import edu.wpi.first.networktables.NetworkTableInstance;
 import edu.wpi.first.networktables.PubSubOption;
 
-public class LoggedTunableString extends LoggedNetworkString {
+public class LoggedTunableString extends LoggedNetworkString implements LoggedTunable<String> {
 
-  private StringEntry entry;
-  private List<Consumer<String>> listeners;
+  private final String defaultValue;
+  private final StringEntry entry;
+  private final List<WeakReference<Consumer<String>>> listeners;
+
+  public String getDefaultValue() {
+    return defaultValue;
+  }
+
+  public String getValue() {
+    return entry.get();
+  }
+
+  public List<WeakReference<Consumer<String>>> getListeners() {
+    return listeners;
+  }
 
   public LoggedTunableString(String key, String defaultValue) {
     super(key, defaultValue);
+    this.defaultValue = defaultValue;
     entry = NetworkTableInstance.getDefault().getStringTopic(key).getEntry(defaultValue,
         PubSubOption.keepDuplicates(false), PubSubOption.pollStorage(1));
     listeners = new ArrayList<>();
   }
 
-  public void addListener(Consumer<String> listener) {
-    listeners.add(listener);
-    listener.accept(entry.get());
-  }
-
-  public void removeListener(Consumer<String> listener) {
-    listeners.remove(listener);
-  }
-
   @Override
   public void periodic() {
     super.periodic();
-    var changes = entry.readQueueValues();
-    if (changes.length == 1) {
-      var newValue = changes[0];
-      for (var listener : listeners) {
-        listener.accept(newValue);
+
+    // Only do tunables when not in a match
+    if (DriverStation.getMatchType() == MatchType.None) {
+      var changes = entry.readQueueValues();
+      if (changes.length == 1) {
+        notifyListeners();
       }
     }
   }

--- a/src/main/java/frc/lib/tunables/LoggedTunableString.java
+++ b/src/main/java/frc/lib/tunables/LoggedTunableString.java
@@ -24,7 +24,7 @@ public class LoggedTunableString extends LoggedNetworkString implements LoggedTu
   }
 
   public String getValue() {
-    return entry.get();
+    return get();
   }
 
   public List<WeakReference<Consumer<String>>> getListeners() {

--- a/src/main/java/frc/robot/Robot25/RobotContainer.java
+++ b/src/main/java/frc/robot/Robot25/RobotContainer.java
@@ -2,8 +2,6 @@
 
 package frc.robot.Robot25;
 
-
-
 import static edu.wpi.first.units.Units.*;
 import com.ctre.phoenix6.signals.NeutralModeValue;
 
@@ -69,7 +67,6 @@ public class RobotContainer extends frc.lib.RobotContainer {
   private final Drive drive;
   private final Elevator elevator;
   private final Outtake outtake;
-  @SuppressWarnings("unused")
   private final Vision vision;
   private final Algae algae;
 
@@ -104,7 +101,7 @@ public class RobotContainer extends frc.lib.RobotContainer {
         drive = new Drive(new GyroIOPigeon2(), new ModuleIOTalonFX(DriveConstants.FrontLeft),
             new ModuleIOTalonFX(DriveConstants.FrontRight),
             new ModuleIOTalonFX(DriveConstants.BackLeft),
-            new ModuleIOTalonFX(DriveConstants.BackRight));
+            new ModuleIOTalonFX(DriveConstants.BackRight), driveSimulation::setSimulationWorldPose);
 
         elevator = new Elevator(new ElevatorIOTalonFXNew());
         outtake = new Outtake(new OuttakeIOTalonFX());
@@ -118,22 +115,23 @@ public class RobotContainer extends frc.lib.RobotContainer {
             new ModuleIOSim(driveSimulation.getModules()[0]),
             new ModuleIOSim(driveSimulation.getModules()[1]),
             new ModuleIOSim(driveSimulation.getModules()[2]),
-            new ModuleIOSim(driveSimulation.getModules()[3]));
+            new ModuleIOSim(driveSimulation.getModules()[3]),
+            driveSimulation::setSimulationWorldPose);
         drive.setPose(SimConstants.SIM_INITIAL_FIELD_POSE);
 
         elevator = new Elevator(new ElevatorIOSim());
         outtake = new Outtake(new OuttakeIOSim());
-        vision = new Vision(drive,
-            new VisionIOPhotonVisionSim(VisionConstants.limelightBackName,
-                VisionConstants.limelightBackTransform, () -> drive.getPose()),
+        vision = new Vision(drive, new VisionIOPhotonVisionSim(VisionConstants.limelightBackName,
+            VisionConstants.limelightBackTransform, driveSimulation::getSimulatedDriveTrainPose),
             new VisionIOPhotonVisionSim(VisionConstants.limelightFrontName,
-                VisionConstants.limelightFrontTransform, () -> drive.getPose()));
+                VisionConstants.limelightFrontTransform,
+                driveSimulation::getSimulatedDriveTrainPose));
         algae = new Algae(new AlgaeIOSim());
         break;
       default:
         // Replayed robot, disable IO implementations
         drive = new Drive(new GyroIO() {}, new ModuleIO() {}, new ModuleIO() {}, new ModuleIO() {},
-            new ModuleIO() {});
+            new ModuleIO() {}, driveSimulation::setSimulationWorldPose);
 
         elevator = new Elevator(new ElevatorIO() {});
 

--- a/src/main/java/frc/robot/Robot25/commands/DriveCharacterization.java
+++ b/src/main/java/frc/robot/Robot25/commands/DriveCharacterization.java
@@ -9,6 +9,9 @@ import edu.wpi.first.wpilibj2.command.Command;
 import edu.wpi.first.wpilibj2.command.Commands;
 import frc.robot.Robot25.subsystems.drive.Drive;
 import frc.robot.Robot25.subsystems.drive.DriveConstants;
+
+import static edu.wpi.first.units.Units.Meters;
+
 import java.text.DecimalFormat;
 import java.text.NumberFormat;
 import java.util.LinkedList;
@@ -126,7 +129,7 @@ public class DriveCharacterization {
                     wheelDelta += Math.abs(positions[i] - state.positions[i]) / 4.0;
                   }
                   double wheelRadius =
-                      (state.gyroDelta * DriveConstants.DRIVE_BASE_RADIUS) / wheelDelta;
+                      (state.gyroDelta * DriveConstants.DRIVE_BASE_RADIUS.in(Meters)) / wheelDelta;
 
                   NumberFormat formatter = new DecimalFormat("#0.000");
                   System.out.println("********** Wheel Radius Characterization Results **********");

--- a/src/main/java/frc/robot/Robot25/commands/DriveCommands.java
+++ b/src/main/java/frc/robot/Robot25/commands/DriveCommands.java
@@ -42,9 +42,6 @@ import org.littletonrobotics.junction.networktables.LoggedNetworkNumber;
 public class DriveCommands {
   private static final double SLOW_MODE_MULTIPLIER = 0.5;
   private static final double DEADBAND = 0.1;
-  // private static final double ANGLE_KP = 7.0;
-  // private static final double ANGLE_KI = 0.0;
-  // private static final double ANGLE_KD = 0.4;
   private static final double ANGLE_MAX_VELOCITY = 8.0;
   private static final double ANGLE_MAX_ACCELERATION = 20.0;
   private static final double ANGLE_TOLERANCE = Degrees.of(1).in(Radians);
@@ -340,7 +337,6 @@ public class DriveCommands {
   };
 
   public static Command snapToPosition(Drive drive, Pose2d desiredPosition) {
-
     return Commands.run(() -> {
 
       var x = xController.calculate(drive.getPose().getX(), desiredPosition.getX());
@@ -367,9 +363,11 @@ public class DriveCommands {
 
         // Reset PID controller when command starts
         .beforeStarting(() -> {
-          angleController.reset(drive.getRotation().getRadians());
-          xController.reset(drive.getPose().getX());
-          yController.reset(drive.getPose().getY());
+          var fieldRelativeSpeeds = drive.getFieldRelativeSpeeds();
+          angleController.reset(drive.getRotation().getRadians(),
+              fieldRelativeSpeeds.omegaRadiansPerSecond);
+          xController.reset(drive.getPose().getX(), fieldRelativeSpeeds.vxMetersPerSecond);
+          yController.reset(drive.getPose().getY(), fieldRelativeSpeeds.vyMetersPerSecond);
         }).until(() -> angleController.atGoal() && xController.atGoal() && yController.atGoal());
   }
 
@@ -442,9 +440,11 @@ public class DriveCommands {
 
         // Reset PID controller when command starts
         .beforeStarting(() -> {
-          angleController.reset(drive.getRotation().getRadians());
-          xController.reset(drive.getPose().getX());
-          yController.reset(drive.getPose().getY());
+          var fieldRelativeSpeeds = drive.getFieldRelativeSpeeds();
+          angleController.reset(drive.getRotation().getRadians(),
+              fieldRelativeSpeeds.omegaRadiansPerSecond);
+          xController.reset(drive.getPose().getX(), fieldRelativeSpeeds.vxMetersPerSecond);
+          yController.reset(drive.getPose().getY(), fieldRelativeSpeeds.vyMetersPerSecond);
         });
   }
 }

--- a/src/main/java/frc/robot/Robot25/commands/DriveCommands.java
+++ b/src/main/java/frc/robot/Robot25/commands/DriveCommands.java
@@ -28,6 +28,8 @@ import edu.wpi.first.math.trajectory.TrapezoidProfile;
 import edu.wpi.first.units.measure.Distance;
 import edu.wpi.first.wpilibj2.command.Command;
 import edu.wpi.first.wpilibj2.command.Commands;
+import edu.wpi.first.wpilibj2.command.ProfiledPIDCommand;
+import frc.lib.tunables.LoggedTunableNumber;
 import frc.robot.Robot25.subsystems.drive.Drive;
 import java.util.Optional;
 import java.util.Set;
@@ -115,26 +117,50 @@ public class DriveCommands {
   private static final Pose2d[] OUTER_REEF_POSITIONS = makeReefPositions(Inches.of(12));
   private static final Pose2d[] INNER_REEF_POSITIONS = makeReefPositions(Inches.of(0));
 
-  // public static final TunableDouble ANGLE_KP =/
-  // new TunableDouble("ANGLE_KP", 7.0, "driver").setSpot(0, 0);
-  // public static final TunableDouble ANGLE_KI =
-  // new TunableDouble("ANGLE_KI", 0.0, "driver").setSpot(1, 0);
-  // public static final TunableDouble ANGLE_KD =
-  // new TunableDouble("ANGLE_KD", 0.4, "driver").setSpot(2, 0);
+  private static final LoggedTunableNumber ANGLE_KP =
+      new LoggedTunableNumber("Tuning/SnapToPosition/Angle_kP", 7.0);
+  private static final LoggedTunableNumber ANGLE_KI =
+      new LoggedTunableNumber("Tuning/SnapToPosition/Angle_kI", 0.0);
+  private static final LoggedTunableNumber ANGLE_KD =
+      new LoggedTunableNumber("Tuning/SnapToPosition/Angle_kD", 0.4);
 
-  public static final LoggedNetworkNumber ANGLE_KP =
-      new LoggedNetworkNumber("/Tuning/angleKP", 7.0);
-  public static final LoggedNetworkNumber ANGLE_KI =
-      new LoggedNetworkNumber("/Tuning/angleKI", 0.0);
-  public static final LoggedNetworkNumber ANGLE_KD =
-      new LoggedNetworkNumber("/Tuning/angleKD", 0.4);
+  private static final LoggedTunableNumber POSITION_KP =
+      new LoggedTunableNumber("Tuning/SnapToPosition/Position_kP", 4);
+  private static final LoggedTunableNumber POSITION_KI =
+      new LoggedTunableNumber("Tuning/SnapToPosition/Position_kI", 0); // 1
+  private static final LoggedTunableNumber POSITION_KD =
+      new LoggedTunableNumber("Tuning/SnapToPosition/Position_kD", 0); // 1
 
-  public static final LoggedNetworkNumber POSITION_KP =
-      new LoggedNetworkNumber("/Tuning/positionKP", 4);
-  public static final LoggedNetworkNumber POSITION_KI =
-      new LoggedNetworkNumber("/Tuning/positionKI", 0); // 1
-  public static final LoggedNetworkNumber POSITION_KD =
-      new LoggedNetworkNumber("/Tuning/positionKD", 0); // 1
+  // Create X Position PID controller
+  private static final ProfiledPIDController xController = new ProfiledPIDController(0, 0, 0,
+      new TrapezoidProfile.Constraints(POSITION_MAX_VELOCITY, POSITION_MAX_ACCELERATION));
+
+  // Create Y Position PID controller
+  private static final ProfiledPIDController yController = new ProfiledPIDController(0, 0, 0,
+      new TrapezoidProfile.Constraints(POSITION_MAX_VELOCITY, POSITION_MAX_ACCELERATION));
+
+  // Create Angle PID controller
+  private static final ProfiledPIDController angleController = new ProfiledPIDController(0, 0, 0,
+      new TrapezoidProfile.Constraints(ANGLE_MAX_VELOCITY, ANGLE_MAX_ACCELERATION));
+
+  static {
+    // Setup PID controllers
+    xController.setTolerance(POSITION_TOLERANCE);
+    yController.setTolerance(POSITION_TOLERANCE);
+    angleController.enableContinuousInput(-Math.PI, Math.PI);
+    angleController.setTolerance(ANGLE_TOLERANCE);
+
+    // This also sets the PID gains immediately
+    POSITION_KP.addListener(xController::setP);
+    POSITION_KI.addListener(xController::setI);
+    POSITION_KD.addListener(xController::setD);
+    POSITION_KP.addListener(yController::setP);
+    POSITION_KI.addListener(yController::setI);
+    POSITION_KD.addListener(yController::setD);
+    ANGLE_KP.addListener(angleController::setP);
+    ANGLE_KI.addListener(angleController::setI);
+    ANGLE_KD.addListener(angleController::setD);
+  }
 
   private DriveCommands() {}
 
@@ -157,18 +183,7 @@ public class DriveCommands {
   public static Command joystickDrive(Drive drive, DoubleSupplier xSupplier,
       DoubleSupplier ySupplier, DoubleSupplier omegaSupplier) {
 
-    // Create PID controller
-    ProfiledPIDController angleController =
-        new ProfiledPIDController(ANGLE_KP.get(), ANGLE_KI.get(), ANGLE_KD.get(),
-            new TrapezoidProfile.Constraints(ANGLE_MAX_VELOCITY, ANGLE_MAX_ACCELERATION));
-    angleController.enableContinuousInput(-Math.PI, Math.PI);
-    angleController.setTolerance(ANGLE_TOLERANCE);
-
     return Commands.run(() -> {
-      angleController.setP(ANGLE_KP.get());
-      angleController.setI(ANGLE_KI.get());
-      angleController.setD(ANGLE_KD.get());
-
       // Get linear velocity
       Translation2d linearVelocity =
           getLinearVelocityFromJoysticks(-xSupplier.getAsDouble(), -ySupplier.getAsDouble());
@@ -207,8 +222,8 @@ public class DriveCommands {
       drive.runVelocity(ChassisSpeeds.fromFieldRelativeSpeeds(speeds, drive.getRotation()));
     }, drive)
 
-        // Reset PID controller when command starts
-        .beforeStarting(() -> angleController.reset(drive.getRotation().getRadians()));
+        // Reset PID controller command starts
+        .beforeStarting(() -> angleController.reset(drive.getRotation().getRadians())); // when
   }
 
   /**
@@ -218,12 +233,6 @@ public class DriveCommands {
    */
   public static Command joystickDriveAtAngle(Drive drive, DoubleSupplier xSupplier,
       DoubleSupplier ySupplier, Supplier<Rotation2d> rotationSupplier) {
-
-    // Create PID controller
-    ProfiledPIDController angleController =
-        new ProfiledPIDController(ANGLE_KP.get(), ANGLE_KI.get(), ANGLE_KD.get(),
-            new TrapezoidProfile.Constraints(ANGLE_MAX_VELOCITY, ANGLE_MAX_ACCELERATION));
-    angleController.enableContinuousInput(-Math.PI, Math.PI);
 
     // Construct command
     return Commands.run(() -> {
@@ -241,7 +250,6 @@ public class DriveCommands {
               linearVelocity.getY() * drive.getMaxLinearSpeedMetersPerSec(), omega);
       drive.runVelocity(ChassisSpeeds.fromFieldRelativeSpeeds(speeds, drive.getRotation()));
     }, drive)
-
         // Reset PID controller when command starts
         .beforeStarting(() -> angleController.reset(drive.getRotation().getRadians()));
   }
@@ -333,36 +341,7 @@ public class DriveCommands {
 
   public static Command snapToPosition(Drive drive, Pose2d desiredPosition) {
 
-    // Create PID controller
-    ProfiledPIDController angleController =
-        new ProfiledPIDController(ANGLE_KP.get(), ANGLE_KI.get(), ANGLE_KD.get(),
-            new TrapezoidProfile.Constraints(ANGLE_MAX_VELOCITY, ANGLE_MAX_ACCELERATION));
-    angleController.enableContinuousInput(-Math.PI, Math.PI);
-    angleController.setTolerance(ANGLE_TOLERANCE);
-
-    ProfiledPIDController xController =
-        new ProfiledPIDController(POSITION_KP.get(), POSITION_KI.get(), POSITION_KD.get(),
-            new TrapezoidProfile.Constraints(POSITION_MAX_VELOCITY, POSITION_MAX_ACCELERATION));
-    xController.setTolerance(POSITION_TOLERANCE);
-
-    ProfiledPIDController yController =
-        new ProfiledPIDController(POSITION_KP.get(), POSITION_KI.get(), POSITION_KD.get(),
-            new TrapezoidProfile.Constraints(POSITION_MAX_VELOCITY, POSITION_MAX_ACCELERATION));
-    yController.setTolerance(POSITION_TOLERANCE);
-
     return Commands.run(() -> {
-
-      angleController.setP(ANGLE_KP.get());
-      angleController.setI(ANGLE_KI.get());
-      angleController.setD(ANGLE_KD.get());
-
-      xController.setP(POSITION_KP.get());
-      xController.setI(POSITION_KI.get());
-      xController.setD(POSITION_KD.get());
-
-      yController.setP(POSITION_KP.get());
-      yController.setI(POSITION_KI.get());
-      yController.setD(POSITION_KD.get());
 
       var x = xController.calculate(drive.getPose().getX(), desiredPosition.getX());
 
@@ -398,36 +377,7 @@ public class DriveCommands {
       DoubleSupplier ySupplier, DoubleSupplier omegaSupplier, BooleanSupplier snapSupplier,
       BooleanSupplier slowModeSupplier) {
 
-    // Create PID controller
-    ProfiledPIDController angleController =
-        new ProfiledPIDController(ANGLE_KP.get(), ANGLE_KI.get(), ANGLE_KD.get(),
-            new TrapezoidProfile.Constraints(ANGLE_MAX_VELOCITY, ANGLE_MAX_ACCELERATION));
-    angleController.enableContinuousInput(-Math.PI, Math.PI);
-    angleController.setTolerance(ANGLE_TOLERANCE);
-
-    ProfiledPIDController xController =
-        new ProfiledPIDController(POSITION_KP.get(), POSITION_KI.get(), POSITION_KD.get(),
-            new TrapezoidProfile.Constraints(POSITION_MAX_VELOCITY, POSITION_MAX_ACCELERATION));
-    xController.setTolerance(POSITION_TOLERANCE);
-
-    ProfiledPIDController yController =
-        new ProfiledPIDController(POSITION_KP.get(), POSITION_KI.get(), POSITION_KD.get(),
-            new TrapezoidProfile.Constraints(POSITION_MAX_VELOCITY, POSITION_MAX_ACCELERATION));
-    yController.setTolerance(POSITION_TOLERANCE);
-
     return Commands.run(() -> {
-
-      angleController.setP(ANGLE_KP.get());
-      angleController.setI(ANGLE_KI.get());
-      angleController.setD(ANGLE_KD.get());
-
-      xController.setP(POSITION_KP.get());
-      xController.setI(POSITION_KI.get());
-      xController.setD(POSITION_KD.get());
-
-      yController.setP(POSITION_KP.get());
-      yController.setI(POSITION_KI.get());
-      yController.setD(POSITION_KD.get());
 
       Logger.recordOutput("InnerReefPositions", DriveCommands.INNER_REEF_POSITIONS);
       Logger.recordOutput("OuterReefPositions", DriveCommands.OUTER_REEF_POSITIONS);
@@ -491,9 +441,7 @@ public class DriveCommands {
     }, drive)
 
         // Reset PID controller when command starts
-        .beforeStarting(() ->
-
-        {
+        .beforeStarting(() -> {
           angleController.reset(drive.getRotation().getRadians());
           xController.reset(drive.getPose().getX());
           yController.reset(drive.getPose().getY());

--- a/src/main/java/frc/robot/Robot25/subsystems/drive/Drive.java
+++ b/src/main/java/frc/robot/Robot25/subsystems/drive/Drive.java
@@ -120,8 +120,8 @@ public class Drive extends SubsystemBase implements VisionConsumer {
 
     // Configure AutoBuilder for PathPlanner
     AutoBuilder.configure(this::getPose, this::setPose, this::getChassisSpeeds, this::runVelocity,
-        new PPHolonomicDriveController(new PIDConstants(0.001, 0.0, 0.0),
-            new PIDConstants(2.0, 0.0, 0.3)),
+        new PPHolonomicDriveController(DriveConstants.PP_TRANSLATION_GAINS,
+            DriveConstants.PP_ROTATION_GAINS),
         PP_CONFIG, () -> DriverStation.getAlliance().orElse(Alliance.Blue) == Alliance.Red, this);
     Pathfinding.setPathfinder(new LocalADStarAK());
     PathPlannerLogging.setLogActivePathCallback((activePath) -> {

--- a/src/main/java/frc/robot/Robot25/subsystems/drive/DriveConstants.java
+++ b/src/main/java/frc/robot/Robot25/subsystems/drive/DriveConstants.java
@@ -7,14 +7,36 @@ import com.ctre.phoenix6.configs.*;
 import com.ctre.phoenix6.signals.StaticFeedforwardSignValue;
 import com.ctre.phoenix6.swerve.*;
 import com.ctre.phoenix6.swerve.SwerveModuleConstants.*;
+import com.pathplanner.lib.config.PIDConstants;
+
 import edu.wpi.first.units.measure.*;
 
 public class DriveConstants {
 
-  /* These constants only affect real hardware */
-  public static class Real {
+  // Stator current limits
+  public static final Current DRIVE_CURRENT_LIMIT = Amps.of(60);
+  public static final Current TURN_CURRENT_LIMIT = Amps.of(60); // TODO consider lowering to about
+                                                                // 40 amps
 
-    /* TODO Both sets of gains need to be tuned to your individual robot */
+  // The stator current at which the wheels start to slip;
+  private static final Current kSlipCurrent = Amps.of(120.0); // TODO measure this
+
+  // PathPlanner and Maple Sim config constants
+  public static final Distance kWheelRadius = Inches.of(2); // TODO measure often
+  public static final double ROBOT_MASS_KG = 54.431;
+  public static final double ROBOT_MOI = 5.98;
+  public static final double WHEEL_COF = 1.542;
+  public static final double kDriveGearRatio = 6.122; // Source: MK4i swerve module page; L3 gearing
+  private static final double kSteerGearRatio = 150.0 / 7.0; // Source: MK4i swerve module page
+  public static final double kMaxDriveMotorRPM = 6000.0;
+  public static final LinearVelocity kSpeedAt12Volts = MetersPerSecond.of(5.22);
+
+  // PID Gains for PathPlanner
+  public static final PIDConstants PP_TRANSLATION_GAINS = new PIDConstants(0.001, 0.0, 0.0);
+  public static final PIDConstants PP_ROTATION_GAINS = new PIDConstants(2.0, 0.0, 0.3);
+
+  /* These Gains constants only affect real hardware */
+  public static class Real {
 
     // The steer motor uses any SwerveModule.SteerRequestType control request with
     // the output type specified by SwerveModuleConstants.SteerMotorClosedLoopOutput
@@ -29,16 +51,10 @@ public class DriveConstants {
             .withKD(0 * METERS_TO_ROTATIONS).withKS(0.065599).withKV(2.2267 * METERS_TO_ROTATIONS)
             .withKA(0.058183 * METERS_TO_ROTATIONS);
 
-    // Curint limits
-    public static final double MaxDriveAmps = 45;
-
   }
 
-  /* These constants only affect simulation */
+  /* These Gains constants only affect simulation */
   public static class Sim {
-
-    // TODO Both sets of gains need to be tuned to your individual robot; practice
-    // tuning in simulation
 
     /* Steer gains */
     public static final double STEER_KS = 0.1;
@@ -61,13 +77,8 @@ public class DriveConstants {
     private static final MomentOfInertia kDriveInertia = KilogramSquareMeters.of(0.01);
 
     private static final Voltage kSteerFrictionVoltage = Volts.of(0.4); // suggested range 0.3 - 0.5
-    private static final Voltage kDriveFrictionVoltage = Volts.of(0.7); // suggested range 0.6 - 0.8
+    private static final Voltage kDriveFrictionVoltage = Volts.of(0.4); // suggested range 0.6 - 0.8
   }
-
-  // PathPlanner and Maple Sim config constants
-  public static final double ROBOT_MASS_KG = 16.21;
-  public static final double ROBOT_MOI = 3.805;
-  public static final double WHEEL_COF = 1.542;
 
   // The closed-loop output type to use for the steer motors;
   // This affects the PID/FF gains for the steer motors
@@ -88,26 +99,19 @@ public class DriveConstants {
   // irrelevant
   private static final SteerFeedbackType kSteerFeedbackType = SteerFeedbackType.RemoteCANcoder;
 
-  // TODO The stator current at which the wheels start to slip;
-  // This needs to be tuned to your individual robot
-  private static final Current kSlipCurrent = Amps.of(120.0);
-
   // Initial configs for the drive and steer motors and the azimuth encoder; these
   // cannot be null.
   // Some configs will be overwritten; check the `with*InitialConfigs()` API
   // documentation.
   private static final TalonFXConfiguration driveInitialConfigs =
       new TalonFXConfiguration().withCurrentLimits(new CurrentLimitsConfigs()
-          .withStatorCurrentLimit(Amps.of(60)).withStatorCurrentLimitEnable(true));
+          .withStatorCurrentLimit(DRIVE_CURRENT_LIMIT).withStatorCurrentLimitEnable(true));
+  // Swerve azimuth does not require much torque output, so we can set a
+  // relatively low stator current limit to help avoid brownouts without impacting
+  // performance.
   private static final TalonFXConfiguration steerInitialConfigs =
       new TalonFXConfiguration().withCurrentLimits(new CurrentLimitsConfigs()
-          // Swerve azimuth does not require much torque output, so we can
-          // set a
-          // relatively
-          // low
-          // stator current limit to help avoid brownouts without
-          // impacting performance.
-          .withStatorCurrentLimit(Amps.of(60)).withStatorCurrentLimitEnable(true));
+          .withStatorCurrentLimit(TURN_CURRENT_LIMIT).withStatorCurrentLimitEnable(true));
 
   // Configs for the Pigeon 2; leave this null to skip applying Pigeon 2 configs
   private static final Pigeon2Configuration pigeonConfigs = new Pigeon2Configuration();
@@ -121,16 +125,6 @@ public class DriveConstants {
   // Every 1 rotation of the azimuth results in kCoupleRatio drive motor turns;
   // This may need to be tuned to your individual robot
   private static final double kCoupleRatio = 3.8181818181818183;
-
-  public static final double kDriveGearRatio = 6.122; // Source: MK4i swerve module page; L3
-                                                      // gearing
-  private static final double kSteerGearRatio = 150.0 / 7.0; // Source: MK4i swerve module page
-  public static final Distance kWheelRadius = Inches.of(2); // TODO measure
-
-  // Theoretical free speed (m/s) at 12 V applied output;
-  // This needs to be tuned to your individual robot
-  public static final double kMaxDriveMotorRPM = 6000.0;
-  public static final LinearVelocity kSpeedAt12Volts = MetersPerSecond.of(5.22);
 
   private static final boolean kInvertLeftSide = false;
   private static final boolean kInvertRightSide = true;

--- a/src/main/java/frc/robot/Robot25/subsystems/drive/DriveConstants.java
+++ b/src/main/java/frc/robot/Robot25/subsystems/drive/DriveConstants.java
@@ -14,7 +14,8 @@ import edu.wpi.first.units.measure.*;
 public class DriveConstants {
 
   // Stator current limits
-  public static final Current DRIVE_CURRENT_LIMIT = Amps.of(60);
+  public static final Current DRIVE_CURRENT_LIMIT = Amps.of(60); // TODO consider raising to 70 or
+                                                                 // 80 amps
   public static final Current TURN_CURRENT_LIMIT = Amps.of(60); // TODO consider lowering to about
                                                                 // 40 amps
 

--- a/src/main/java/frc/robot/Robot25/subsystems/drive/DriveConstants.java
+++ b/src/main/java/frc/robot/Robot25/subsystems/drive/DriveConstants.java
@@ -122,17 +122,15 @@ public class DriveConstants {
   // This may need to be tuned to your individual robot
   private static final double kCoupleRatio = 3.8181818181818183;
 
-  private static final double kDriveGearRatio = 6.122; // Source: MK4i swerve module page; L3
-                                                       // gearing
+  public static final double kDriveGearRatio = 6.122; // Source: MK4i swerve module page; L3
+                                                      // gearing
   private static final double kSteerGearRatio = 150.0 / 7.0; // Source: MK4i swerve module page
-  private static final Distance kWheelRadius = Inches.of(2); // TODO measure
+  public static final Distance kWheelRadius = Inches.of(2); // TODO measure
 
   // Theoretical free speed (m/s) at 12 V applied output;
   // This needs to be tuned to your individual robot
   public static final double kMaxDriveMotorRPM = 6000.0;
-  public static final LinearVelocity kSpeedAt12Volts = MetersPerSecond
-      .of(Math.PI * kWheelRadius.in(Meters) * 2 * kMaxDriveMotorRPM / 60 / kDriveGearRatio); // 5.22
-                                                                                             // m/s
+  public static final LinearVelocity kSpeedAt12Volts = MetersPerSecond.of(5.22);
 
   private static final boolean kInvertLeftSide = false;
   private static final boolean kInvertRightSide = true;
@@ -216,11 +214,14 @@ public class DriveConstants {
           kInvertRightSide, kBackRightSteerMotorInverted, kBackRightEncoderInverted);
 
   // For max angular velocity calculations
-  public static final double DRIVE_BASE_RADIUS = Math.max(
+  public static final Distance DRIVE_BASE_RADIUS = Meters.of(Math.max(
       Math.max(Math.hypot(DriveConstants.FrontLeft.LocationX, DriveConstants.FrontRight.LocationY),
           Math.hypot(DriveConstants.FrontRight.LocationX, DriveConstants.FrontRight.LocationY)),
       Math.max(Math.hypot(DriveConstants.BackLeft.LocationX, DriveConstants.BackLeft.LocationY),
-          Math.hypot(DriveConstants.BackRight.LocationX, DriveConstants.BackRight.LocationY)));
+          Math.hypot(DriveConstants.BackRight.LocationX, DriveConstants.BackRight.LocationY))));
+
+  public static final AngularVelocity MAX_ANGULAR_VELOCITY =
+      RadiansPerSecond.of(kSpeedAt12Volts.in(MetersPerSecond) / DRIVE_BASE_RADIUS.in(Meters));
 
   public static final double ODOMETRY_FREQUENCY =
       new CANBus(DriveConstants.DrivetrainConstants.CANBusName).isNetworkFD() ? 250.0 : 100.0;

--- a/src/main/java/frc/robot/Robot25/subsystems/drive/ModuleIOTalonFX.java
+++ b/src/main/java/frc/robot/Robot25/subsystems/drive/ModuleIOTalonFX.java
@@ -94,15 +94,11 @@ public class ModuleIOTalonFX implements ModuleIO {
   private final Debouncer driveConnectedDebounce = new Debouncer(0.5);
   private final Debouncer turnConnectedDebounce = new Debouncer(0.5);
 
-  // private final Debouncer turnEncoderConnectedDebounce = new Debouncer(0.5);
-
   public ModuleIOTalonFX(
       SwerveModuleConstants<TalonFXConfiguration, TalonFXConfiguration, CANcoderConfiguration> constants) {
     this.constants = constants;
     driveTalon = new TalonFX(constants.DriveMotorId, DriveConstants.DrivetrainConstants.CANBusName);
     turnTalon = new TalonFX(constants.SteerMotorId, DriveConstants.DrivetrainConstants.CANBusName);
-    // cancoder = new CANcoder(constants.EncoderId,
-    // DriveConstants.DrivetrainConstants.CANBusName);
     customEncoder = new PWMEncoder(constants.EncoderId, Rotations.of(constants.EncoderOffset));
 
     // Configure drive motor
@@ -112,8 +108,6 @@ public class ModuleIOTalonFX implements ModuleIO {
     driveConfig.Feedback.SensorToMechanismRatio = constants.DriveMotorGearRatio;
     driveConfig.TorqueCurrent.PeakForwardTorqueCurrent = constants.SlipCurrent;
     driveConfig.TorqueCurrent.PeakReverseTorqueCurrent = -constants.SlipCurrent;
-    driveConfig.CurrentLimits.StatorCurrentLimit = DriveConstants.Real.MaxDriveAmps;
-    driveConfig.CurrentLimits.StatorCurrentLimitEnable = true;
     driveConfig.MotorOutput.Inverted =
         constants.DriveMotorInverted ? InvertedValue.Clockwise_Positive
             : InvertedValue.CounterClockwise_Positive;
@@ -138,15 +132,6 @@ public class ModuleIOTalonFX implements ModuleIO {
             : InvertedValue.CounterClockwise_Positive;
     tryUntilOk(5, () -> turnTalon.getConfigurator().apply(turnConfig, 0.25));
     tryUntilOk(5, () -> turnTalon.setPosition(customEncoder.getPosition(), 0.25));
-
-    // Configure CANCoder
-    // CANcoderConfiguration cancoderConfig = constants.EncoderInitialConfigs;
-    // cancoderConfig.MagnetSensor.MagnetOffset = constants.EncoderOffset;
-    // cancoderConfig.MagnetSensor.SensorDirection =
-    // constants.EncoderInverted
-    // ? SensorDirectionValue.Clockwise_Positive
-    // : SensorDirectionValue.CounterClockwise_Positive;
-    // cancoder.getConfigurator().apply(cancoderConfig);
 
     // Create timestamp queue
     timestampQueue = PhoenixOdometryThread.getInstance().makeTimestampQueue();
@@ -198,7 +183,6 @@ public class ModuleIOTalonFX implements ModuleIO {
     // Update turn inputs
     inputs.turnConnected = turnConnectedDebounce.calculate(turnStatus.isOK());
     inputs.turnEncoderConnected = true;
-    // turnEncoderConnectedDebounce.calculate(turnEncoderStatus.isOK());
     inputs.turnAbsolutePosition = new Rotation2d(turnAbsolutePosition.get());
     inputs.turnPosition = Rotation2d.fromRotations(turnPosition.getValueAsDouble());
     inputs.turnVelocityRadPerSec = Units.rotationsToRadians(turnVelocity.getValueAsDouble());

--- a/src/main/java/frc/robot/Robot25/subsystems/outtake/OuttakeIOSim.java
+++ b/src/main/java/frc/robot/Robot25/subsystems/outtake/OuttakeIOSim.java
@@ -14,11 +14,11 @@ import edu.wpi.first.units.measure.AngularVelocity;
 import edu.wpi.first.units.measure.Voltage;
 import edu.wpi.first.wpilibj.TimedRobot;
 import edu.wpi.first.wpilibj.simulation.FlywheelSim;
+import frc.lib.tunables.LoggedTunableBoolean;
 import frc.robot.Robot25.subsystems.outtake.OuttakeConstants.Sim;
 import org.ironmaple.simulation.motorsims.MapleMotorSim;
 import org.ironmaple.simulation.motorsims.SimMotorConfigs;
 import org.ironmaple.simulation.motorsims.SimulatedMotorController;
-import org.littletonrobotics.junction.networktables.LoggedNetworkBoolean;
 
 public class OuttakeIOSim implements OuttakeIO {
   private static final DCMotor outtakeGearbox = DCMotor.getKrakenX60(1);
@@ -26,24 +26,19 @@ public class OuttakeIOSim implements OuttakeIO {
   private final MapleMotorSim outtakeMotor;
   private boolean isClosedLoop = false;
   private Voltage outtakeAppliedVoltage = Volts.of(0);
-  private final SimpleMotorFeedforward feedForwardController =
-      new SimpleMotorFeedforward(Sim.kS, Sim.kV, Sim.kA);
+  private final SimpleMotorFeedforward feedForwardController = new SimpleMotorFeedforward(Sim.kS, Sim.kV, Sim.kA);
 
-  private final FlywheelSim outtakeSim =
-      new FlywheelSim(LinearSystemId.createFlywheelSystem(outtakeGearbox, 0.1, // To Do: Estimate
-                                                                               // this value
-          GEARING), outtakeGearbox, 0.000015);
+  private final FlywheelSim outtakeSim = new FlywheelSim(
+      LinearSystemId.createFlywheelSystem(outtakeGearbox, 0.1, GEARING), outtakeGearbox, 0.000015);
 
-  LoggedNetworkBoolean LoadSideSensor = new LoggedNetworkBoolean("/Tuning/LoadSideSensor", false);
-  LoggedNetworkBoolean ScoreSideSensor = new LoggedNetworkBoolean("/Tuning/ScoreSideSensor", false);
+  LoggedTunableBoolean LoadSideSensor = new LoggedTunableBoolean("Tuning/Outtake/LoadSideSensor", false);
+  LoggedTunableBoolean ScoreSideSensor = new LoggedTunableBoolean("Tuning/Outtake/ScoreSideSensor", false);
 
   public OuttakeIOSim() {
     outtakeMotor = new MapleMotorSim(
         new SimMotorConfigs(outtakeGearbox, GEARING, Sim.MOTOR_LOAD_MOI, Sim.FRICTION_VOLTAGE));
-    outtakeMotorController =
-        outtakeMotor.useSimpleDCMotorController().withCurrentLimit(CURRENT_LIMIT);
+    outtakeMotorController = outtakeMotor.useSimpleDCMotorController().withCurrentLimit(CURRENT_LIMIT);
   }
-
 
   @Override
   public void setOpenLoop(Voltage output) {

--- a/src/main/java/frc/robot/Robot25/subsystems/outtake/OuttakeIOSim.java
+++ b/src/main/java/frc/robot/Robot25/subsystems/outtake/OuttakeIOSim.java
@@ -26,18 +26,22 @@ public class OuttakeIOSim implements OuttakeIO {
   private final MapleMotorSim outtakeMotor;
   private boolean isClosedLoop = false;
   private Voltage outtakeAppliedVoltage = Volts.of(0);
-  private final SimpleMotorFeedforward feedForwardController = new SimpleMotorFeedforward(Sim.kS, Sim.kV, Sim.kA);
+  private final SimpleMotorFeedforward feedForwardController =
+      new SimpleMotorFeedforward(Sim.kS, Sim.kV, Sim.kA);
 
   private final FlywheelSim outtakeSim = new FlywheelSim(
       LinearSystemId.createFlywheelSystem(outtakeGearbox, 0.1, GEARING), outtakeGearbox, 0.000015);
 
-  LoggedTunableBoolean LoadSideSensor = new LoggedTunableBoolean("Tuning/Outtake/LoadSideSensor", false);
-  LoggedTunableBoolean ScoreSideSensor = new LoggedTunableBoolean("Tuning/Outtake/ScoreSideSensor", false);
+  LoggedTunableBoolean LoadSideSensor =
+      new LoggedTunableBoolean("Tuning/Outtake/LoadSideSensor", false);
+  LoggedTunableBoolean ScoreSideSensor =
+      new LoggedTunableBoolean("Tuning/Outtake/ScoreSideSensor", false);
 
   public OuttakeIOSim() {
     outtakeMotor = new MapleMotorSim(
         new SimMotorConfigs(outtakeGearbox, GEARING, Sim.MOTOR_LOAD_MOI, Sim.FRICTION_VOLTAGE));
-    outtakeMotorController = outtakeMotor.useSimpleDCMotorController().withCurrentLimit(CURRENT_LIMIT);
+    outtakeMotorController =
+        outtakeMotor.useSimpleDCMotorController().withCurrentLimit(CURRENT_LIMIT);
   }
 
   @Override

--- a/src/main/java/frc/robot/Robot25/subsystems/vision/VisionIOLimelight.java
+++ b/src/main/java/frc/robot/Robot25/subsystems/vision/VisionIOLimelight.java
@@ -62,20 +62,10 @@ public class VisionIOLimelight implements VisionIO {
         limelightTable.getDoubleArrayTopic("botpose_wpiblue").subscribe(new double[] {});
     megatag2Subscriber =
         limelightTable.getDoubleArrayTopic("botpose_orb_wpiblue").subscribe(new double[] {});
-
-
-
   }
-
-
 
   @Override
   public void updateInputs(VisionIOInputs inputs) {
-    // if (alliance != DriverStation.getAlliance().orElse(Alliance.Blue)) {
-    // setUpMegaTags();
-    // alliance = DriverStation.getAlliance().get();
-    // }
-
     // Update connection status based on whether an update has been seen in the last
     // 250ms
     inputs.connected =


### PR DESCRIPTION
# Some code debt things
- Tunables previous held strong refs to their listeners, bad for heap use, fixed by using weak refs
- Consolidated PID controllers in DriveCommands since they all use the same gains, using new Tunables
  - Reduces heap allocation
- Moved regularly used constants to the top of DriveConstants.
- Moved path planner PID gains to DriveConstants
- Autos work better in Sim by using recommended method to reset sim pose
