### PR TITLE
Feature: enhanced swerve setpoint generator

### DIFF
--- a/src/main/java/frc/robot/Robot25/subsystems/drive/Drive.java
+++ b/src/main/java/frc/robot/Robot25/subsystems/drive/Drive.java
@@ -68,29 +68,30 @@ import org.littletonrobotics.junction.Logger;
 public class Drive extends SubsystemBase implements VisionConsumer {
 
   // Configure path planner
-  private static final RobotConfig PP_CONFIG = new RobotConfig(DriveConstants.ROBOT_MASS_KG, DriveConstants.ROBOT_MOI,
-      new ModuleConfig(DriveConstants.kWheelRadius.in(Meters),
-          DriveConstants.kSpeedAt12Volts.in(MetersPerSecond), DriveConstants.WHEEL_COF,
-          DCMotor.getKrakenX60(1).withReduction(DriveConstants.kDriveGearRatio),
-          DriveConstants.FrontLeft.SlipCurrent, 1),
-      getModuleTranslations());
+  private static final RobotConfig PP_CONFIG =
+      new RobotConfig(DriveConstants.ROBOT_MASS_KG, DriveConstants.ROBOT_MOI,
+          new ModuleConfig(DriveConstants.kWheelRadius.in(Meters),
+              DriveConstants.kSpeedAt12Volts.in(MetersPerSecond), DriveConstants.WHEEL_COF,
+              DCMotor.getKrakenX60(1).withReduction(DriveConstants.kDriveGearRatio),
+              DriveConstants.FrontLeft.SlipCurrent, 1),
+          getModuleTranslations());
 
   // Maple Sim config constants
-  public static final DriveTrainSimulationConfig MAPLE_SIM_CONFIG = DriveTrainSimulationConfig.Default()
-      .withRobotMass(Kilograms.of(DriveConstants.ROBOT_MASS_KG))
-      .withCustomModuleTranslations(getModuleTranslations()).withGyro(COTS.ofPigeon2())
-      .withSwerveModule(new SwerveModuleSimulationConfig(DCMotor.getKrakenX60(1),
-          DCMotor.getFalcon500(1), DriveConstants.FrontLeft.DriveMotorGearRatio,
-          DriveConstants.FrontLeft.SteerMotorGearRatio,
-          Volts.of(DriveConstants.FrontLeft.DriveFrictionVoltage),
-          Volts.of(DriveConstants.FrontLeft.SteerFrictionVoltage),
-          Meters.of(DriveConstants.FrontLeft.WheelRadius),
-          KilogramSquareMeters.of(DriveConstants.FrontLeft.SteerInertia),
-          DriveConstants.WHEEL_COF));
+  public static final DriveTrainSimulationConfig MAPLE_SIM_CONFIG =
+      DriveTrainSimulationConfig.Default().withRobotMass(Kilograms.of(DriveConstants.ROBOT_MASS_KG))
+          .withCustomModuleTranslations(getModuleTranslations()).withGyro(COTS.ofPigeon2())
+          .withSwerveModule(new SwerveModuleSimulationConfig(DCMotor.getKrakenX60(1),
+              DCMotor.getFalcon500(1), DriveConstants.FrontLeft.DriveMotorGearRatio,
+              DriveConstants.FrontLeft.SteerMotorGearRatio,
+              Volts.of(DriveConstants.FrontLeft.DriveFrictionVoltage),
+              Volts.of(DriveConstants.FrontLeft.SteerFrictionVoltage),
+              Meters.of(DriveConstants.FrontLeft.WheelRadius),
+              KilogramSquareMeters.of(DriveConstants.FrontLeft.SteerInertia),
+              DriveConstants.WHEEL_COF));
 
   // Enhanced swerve setpoint generator
-  private final SwerveSetpointGenerator swerveSetpointGenerator = new SwerveSetpointGenerator(PP_CONFIG,
-      DriveConstants.MAX_ANGULAR_VELOCITY);
+  private final SwerveSetpointGenerator swerveSetpointGenerator =
+      new SwerveSetpointGenerator(PP_CONFIG, DriveConstants.MAX_ANGULAR_VELOCITY);
   private SwerveSetpoint previousSetpoint;
 
   static final Lock odometryLock = new ReentrantLock();
@@ -98,16 +99,16 @@ public class Drive extends SubsystemBase implements VisionConsumer {
   private final GyroIOInputsAutoLogged gyroInputs = new GyroIOInputsAutoLogged();
   private final Module[] modules = new Module[4]; // FL, FR, BL, BR
   private final SysIdRoutine sysId;
-  private final Alert gyroDisconnectedAlert = new Alert("Disconnected gyro, using kinematics as fallback.",
-      AlertType.kError);
+  private final Alert gyroDisconnectedAlert =
+      new Alert("Disconnected gyro, using kinematics as fallback.", AlertType.kError);
 
   private SwerveDriveKinematics kinematics = new SwerveDriveKinematics(getModuleTranslations());
   private Rotation2d rawGyroRotation = Rotation2d.kZero;
   private SwerveModulePosition[] lastModulePositions = // For delta tracking
-      new SwerveModulePosition[] { new SwerveModulePosition(), new SwerveModulePosition(),
-          new SwerveModulePosition(), new SwerveModulePosition() };
-  private SwerveDrivePoseEstimator poseEstimator = new SwerveDrivePoseEstimator(kinematics, rawGyroRotation,
-      lastModulePositions, Pose2d.kZero);
+      new SwerveModulePosition[] {new SwerveModulePosition(), new SwerveModulePosition(),
+          new SwerveModulePosition(), new SwerveModulePosition()};
+  private SwerveDrivePoseEstimator poseEstimator =
+      new SwerveDrivePoseEstimator(kinematics, rawGyroRotation, lastModulePositions, Pose2d.kZero);
 
   private boolean coastModeOn = false;
   private boolean snapToRotationEnabled = false;
@@ -219,7 +220,8 @@ public class Drive extends SubsystemBase implements VisionConsumer {
    */
   public void runVelocity(ChassisSpeeds speeds) {
     // Calculate module setpoints
-    previousSetpoint = swerveSetpointGenerator.generateSetpoint(previousSetpoint, speeds, TimedRobot.kDefaultPeriod);
+    previousSetpoint = swerveSetpointGenerator.generateSetpoint(previousSetpoint, speeds,
+        TimedRobot.kDefaultPeriod);
     var setpointStates = previousSetpoint.moduleStates();
 
     // Log unoptimized setpoints and setpoint speeds
@@ -253,10 +255,8 @@ public class Drive extends SubsystemBase implements VisionConsumer {
   }
 
   /**
-   * Stops the drive and turns the modules to an X arrangement to resist movement.
-   * The modules will
-   * return to their normal orientations the next time a nonzero velocity is
-   * requested.
+   * Stops the drive and turns the modules to an X arrangement to resist movement. The modules will
+   * return to their normal orientations the next time a nonzero velocity is requested.
    */
   public void stopWithX() {
     Rotation2d[] headings = new Rotation2d[4];
@@ -296,8 +296,7 @@ public class Drive extends SubsystemBase implements VisionConsumer {
   }
 
   /**
-   * Returns the module states (turn angles and drive velocities) for all of the
-   * modules.
+   * Returns the module states (turn angles and drive velocities) for all of the modules.
    */
   @AutoLogOutput(key = "SwerveStates/Measured")
   private SwerveModuleState[] getModuleStates() {
@@ -309,8 +308,7 @@ public class Drive extends SubsystemBase implements VisionConsumer {
   }
 
   /**
-   * Returns the module positions (turn angles and drive positions) for all of the
-   * modules.
+   * Returns the module positions (turn angles and drive positions) for all of the modules.
    */
   private SwerveModulePosition[] getModulePositions() {
     SwerveModulePosition[] states = new SwerveModulePosition[4];
@@ -336,8 +334,7 @@ public class Drive extends SubsystemBase implements VisionConsumer {
   }
 
   /**
-   * Returns the average velocity of the modules in rotations/sec (Phoenix native
-   * units).
+   * Returns the average velocity of the modules in rotations/sec (Phoenix native units).
    */
   public double getFFCharacterizationVelocity() {
     double output = 0.0;
@@ -388,7 +385,7 @@ public class Drive extends SubsystemBase implements VisionConsumer {
         new Translation2d(DriveConstants.FrontLeft.LocationX, DriveConstants.FrontLeft.LocationY),
         new Translation2d(DriveConstants.FrontRight.LocationX, DriveConstants.FrontRight.LocationY),
         new Translation2d(DriveConstants.BackLeft.LocationX, DriveConstants.BackLeft.LocationY),
-        new Translation2d(DriveConstants.BackRight.LocationX, DriveConstants.BackRight.LocationY) };
+        new Translation2d(DriveConstants.BackRight.LocationX, DriveConstants.BackRight.LocationY)};
   }
 
   public void toggleCoast() {

--- a/src/main/java/frc/robot/Robot25/subsystems/drive/Drive.java
+++ b/src/main/java/frc/robot/Robot25/subsystems/drive/Drive.java
@@ -219,7 +219,7 @@ public class Drive extends SubsystemBase implements VisionConsumer {
    */
   public void runVelocity(ChassisSpeeds speeds) {
     // Calculate module setpoints
-    previousSetpoint = swerveSetpointGenerator.generateSetpoint(previousSetpoint, speeds, 0.02);
+    previousSetpoint = swerveSetpointGenerator.generateSetpoint(previousSetpoint, speeds, TimedRobot.kDefaultPeriod);
     var setpointStates = previousSetpoint.moduleStates();
 
     // Log unoptimized setpoints and setpoint speeds


### PR DESCRIPTION
Using the PathPlanner recommended swerve setpoint generator, adapted from 254's.
See the docs [here](https://pathplanner.dev/pplib-swerve-setpoint-generator.html)

Replaced the default kinematics swerve setpoint generator with the enhanced one
